### PR TITLE
feat!: add async module configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,7 +32,8 @@
     "test": "jest",
     "test:watch": "jest --watch",
     "test:cov": "jest --coverage",
-    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand"
+    "test:debug": "node --inspect-brk -r tsconfig-paths/register -r ts-node/register node_modules/.bin/jest --runInBand",
+    "test:clear": "jest --clearCache true --clearMocks true && jest"
   },
   "dependencies": {
     "debug": "^4.3.1",

--- a/src/constant/index.ts
+++ b/src/constant/index.ts
@@ -1,0 +1,1 @@
+export * from './queue.const';

--- a/src/constant/queue.const.ts
+++ b/src/constant/queue.const.ts
@@ -1,0 +1,3 @@
+export const QUEUE_MODULE_OPTIONS = 'QueueModuleOptions';
+export const AMQP_CLIENT_TOKEN = 'AMQP_CLIENT';
+export const AMQP_CONNECTION_RECONNECT = 'amqp_connection_reconnect';

--- a/src/interface/amqp-connection-options.interface.ts
+++ b/src/interface/amqp-connection-options.interface.ts
@@ -5,7 +5,9 @@ import { ConnectionOptions } from 'rhea-promise';
  *
  * @publicApi
  */
-export type AMQPConnectionOptions = ConnectionOptions & {
+export type QueueModuleOptions = {
   throwExceptionOnConnectionError?: boolean;
   acceptValidationNullObjectException?: boolean;
+  connectionUri?: string;
+  connectionOptions?: ConnectionOptions;
 };

--- a/src/interface/index.ts
+++ b/src/interface/index.ts
@@ -1,2 +1,3 @@
 export * from './amqp-connection-options.interface';
 export * from './queue.interface';
+export * from './queue-options.interface';

--- a/src/interface/queue-options.interface.ts
+++ b/src/interface/queue-options.interface.ts
@@ -1,0 +1,14 @@
+import { ModuleMetadata, Type } from '@nestjs/common';
+
+import { QueueModuleOptions } from './index';
+
+export interface QueueModuleOptionsFactory {
+  createQueueModuleOptions(): Promise<QueueModuleOptions> | QueueModuleOptions;
+}
+
+export interface QueueModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
+  useExisting?: Type<QueueModuleOptionsFactory>;
+  useClass?: Type<QueueModuleOptionsFactory>;
+  useFactory?: (...args: any[]) => Promise<QueueModuleOptions> | QueueModuleOptions;
+  inject?: any[];
+}

--- a/src/interface/queue.interface.ts
+++ b/src/interface/queue.interface.ts
@@ -1,6 +1,6 @@
 import { Message } from 'rhea-promise';
 
-import { ObjectValidationOptions } from '../util/object-validator';
+import { ObjectValidationOptions } from '../service';
 
 /**
  * Interface defining options that can be passed to `@Listen()` decorator

--- a/src/queue.module.spec.ts
+++ b/src/queue.module.spec.ts
@@ -1,0 +1,143 @@
+import { Injectable, Module } from '@nestjs/common';
+import { Test, TestingModule } from '@nestjs/testing';
+
+jest.mock('rhea-promise');
+
+import { QueueModuleOptions, QueueModuleOptionsFactory } from './interface';
+import { QueueModule } from './queue.module';
+import { AMQPService, QueueService } from './service';
+
+describe('QueueModule', () => {
+  const connectionUri = 'amqp://localhost:5672';
+  const moduleOptions: QueueModuleOptions = {
+    connectionUri,
+  };
+  const originalModuleProviders = (QueueModule as any).moduleDefinition.providers;
+  let module: TestingModule;
+
+  @Injectable()
+  class TestForFeatureService {
+    constructor(public readonly queueService: QueueService) {}
+  }
+
+  @Module({
+    imports: [QueueModule.forFeature()],
+    providers: [TestForFeatureService],
+    exports: [TestForFeatureService],
+  })
+  class TestForFeatureModule {}
+
+  @Injectable()
+  class TestConfigService {
+    public getAmqpUrl(): string {
+      return connectionUri;
+    }
+  }
+
+  @Module({
+    providers: [TestConfigService],
+    exports: [TestConfigService],
+  })
+  class TestConfigModule {}
+
+  @Injectable()
+  class TestQueueConfigService implements QueueModuleOptionsFactory {
+    public async createQueueModuleOptions(): Promise<QueueModuleOptions> {
+      return { connectionUri };
+    }
+  }
+
+  @Module({
+    providers: [TestQueueConfigService],
+    exports: [TestQueueConfigService],
+  })
+  class TestQueueConfigModule {}
+
+  afterEach(async () => {
+    await module.close();
+    (QueueModule as any).moduleDefinition.imports = [];
+    (QueueModule as any).moduleDefinition.providers = originalModuleProviders;
+  });
+
+  describe('forRoot()', () => {
+    it('should import as sync root module', async () => {
+      module = await Test.createTestingModule({
+        imports: [QueueModule.forRoot(connectionUri)],
+      }).compile();
+      const amqpService = module.get<AMQPService>(AMQPService);
+
+      expect(amqpService.getModuleOptions()).toEqual(moduleOptions);
+    });
+  });
+
+  describe('forFeature()', () => {
+    it('should import as feature module', async () => {
+      module = await Test.createTestingModule({
+        imports: [QueueModule.forRoot(connectionUri), TestForFeatureModule],
+      }).compile();
+      const forFeatureTestService = module.get<TestForFeatureService>(TestForFeatureService);
+
+      expect((forFeatureTestService.queueService as any).amqpService.getModuleOptions()).toEqual(moduleOptions);
+    });
+  });
+
+  describe('forRootAsync()', () => {
+    it(`should import as sync module with 'useFactory'`, async () => {
+      module = await Test.createTestingModule({
+        imports: [
+          QueueModule.forRootAsync({
+            useFactory: () => ({ connectionUri }),
+          }),
+        ],
+      }).compile();
+      const amqpService = module.get<AMQPService>(AMQPService);
+
+      expect(amqpService.getModuleOptions()).toEqual({ connectionUri });
+    });
+
+    it(`should import as async module with 'useFactory'`, async () => {
+      module = await Test.createTestingModule({
+        imports: [
+          QueueModule.forRootAsync({
+            imports: [TestConfigModule],
+            inject: [TestConfigService],
+            useFactory: (testConfigService: TestConfigService) => ({
+              connectionUri: testConfigService.getAmqpUrl(),
+            }),
+          }),
+        ],
+      }).compile();
+      const amqpService = module.get<AMQPService>(AMQPService);
+
+      expect(amqpService.getModuleOptions()).toEqual({ connectionUri });
+    });
+
+    it(`should import as async module with 'useClass'`, async () => {
+      module = await Test.createTestingModule({
+        imports: [
+          QueueModule.forRootAsync({
+            imports: [TestQueueConfigModule],
+            useClass: TestQueueConfigService,
+          }),
+        ],
+      }).compile();
+      const amqpService = module.get<AMQPService>(AMQPService);
+
+      expect(amqpService.getModuleOptions()).toEqual({ connectionUri });
+    });
+
+    it(`should import as async module with 'useExisting'`, async () => {
+      module = await Test.createTestingModule({
+        imports: [
+          QueueModule.forRootAsync({
+            imports: [TestQueueConfigModule],
+            useExisting: TestQueueConfigService,
+          }),
+        ],
+      }).compile();
+      const amqpService = module.get<AMQPService>(AMQPService);
+
+      expect(amqpService.getModuleOptions()).toEqual({ connectionUri });
+    });
+  });
+});

--- a/src/service/index.ts
+++ b/src/service/index.ts
@@ -1,2 +1,3 @@
 export * from './amqp/amqp.service';
+export * from './object-validator/object-validator.service';
 export * from './queue/queue.service';

--- a/src/service/object-validator/object-validator.service.spec.ts
+++ b/src/service/object-validator/object-validator.service.spec.ts
@@ -2,11 +2,11 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { Expose } from 'class-transformer';
 import { IsNumber, IsString } from 'class-validator';
 
-import { ObjectValidator } from './object-validator';
-import { ValidationNullObjectException } from '../exceptions';
+import { ObjectValidatorService } from './object-validator.service';
+import { ValidationNullObjectException } from '../../util/exceptions';
 
 describe('ObjectValidator', () => {
-  let service: ObjectValidator;
+  let service: ObjectValidatorService;
 
   @Expose()
   class UserDto1 {
@@ -31,9 +31,9 @@ describe('ObjectValidator', () => {
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
-      providers: [ObjectValidator],
+      providers: [ObjectValidatorService],
     }).compile();
-    service = module.get<ObjectValidator>(ObjectValidator);
+    service = module.get<ObjectValidatorService>(ObjectValidatorService);
   });
 
   it('should be defined', () => {

--- a/src/service/object-validator/object-validator.service.ts
+++ b/src/service/object-validator/object-validator.service.ts
@@ -2,7 +2,7 @@ import { Injectable } from '@nestjs/common';
 import { ClassTransformOptions, plainToClass } from 'class-transformer';
 import { validate, ValidationError, ValidatorOptions } from 'class-validator';
 
-import { ValidationNullObjectException } from '../exceptions';
+import { ValidationNullObjectException } from '../../util/exceptions';
 
 export interface ObjectValidationOptions {
   transformerOptions?: ClassTransformOptions;
@@ -13,7 +13,7 @@ export interface ObjectValidationOptions {
  * Class to validate an object or an array of objects.
  */
 @Injectable()
-export class ObjectValidator {
+export class ObjectValidatorService {
   /**
    * Validate and transform a source object by a decorated class. It works with
    * the `class-validator` and the `class-transformer` packages.

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,6 +1,4 @@
 export * from './exceptions';
 export * from './functions';
 export * from './logger';
-export * from './object-validator';
-
 export * from './util.module';

--- a/src/util/object-validator/index.ts
+++ b/src/util/object-validator/index.ts
@@ -1,1 +1,0 @@
-export * from './object-validator';

--- a/src/util/util.module.ts
+++ b/src/util/util.module.ts
@@ -1,9 +1,7 @@
 import { Module } from '@nestjs/common';
 
-import { ObjectValidator } from './object-validator';
-
 @Module({
-  exports: [ObjectValidator],
-  providers: [ObjectValidator],
+  exports: [],
+  providers: [],
 })
 export class UtilModule {}

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "sourceMap": true
+  },
+  "exclude": ["node_modules", "**/*spec.ts", "example", "src/test", "dist"]
+}


### PR DESCRIPTION
BREAKING CHANGE: `QueueModule.forRoot()` connection argument interface was restructured and `AMQPService.getConnectionOptions()`was renamed to `AMQPService.getModuleOptions()`.

This PR contains:
* add `QueueModule.forRootAsync()` method for async module configuration
* add test to `QueueModule`
* rename `AMQPService.getConnectionOptions()` method to `AMQPService.getModuleOptions()`
* rename `AMQPConnectionOptions` to `QueueModuleOptions`
* restructure the `QueueModuleOptions` object: move the rhea `Connection` options into the `connectionOptions` property