### PR TITLE
feat(queue): add support to work only with module options arg

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ connection options or other library settings with the module options.
 
 To create a connection, you have to import the `QueueModule.forRoot()` module into your application's root module. The `forRoot()`
 static method has 2 parameters: the first and required is the connection URI string, and the second is the *optional* module 
-options object. To see the available module options, scroll down. Here is the example: 
+options object, or you can just pass the module options object to it. To see the available module options, scroll down.
+Here is the example: 
 
 > Note: the @team-supercharge/nest-amqp package does not support multiple connection!
 
@@ -53,7 +54,8 @@ import { QueueModule } from '@team-supercharge/nest-amqp';
 @Module({
   imports: [
     QueueModule.forRoot('amqp://user:password@localhost:5672'),
-    // ...
+    // or alternatively
+    // QueueModule.forRoot({ connectionUri: 'amqp://user:password@localhost:5672' }),
   ],
 })
 export class AppModule {}
@@ -81,7 +83,7 @@ import { QueueModule, QueueModuleOptions } from '@team-supercharge/nest-amqp';
       useFactory: (configService: ConfigService): QueueModuleOptions => ({
         connectionUri: configService.get<string>('AMQP_CONNECTION_URI'),
         connectionOptions: {
-          transport: 'tcp'
+          transport: configService.get<string>('AMQP_CONNECTION_TRANSPORT'),
         }
       }),
       inject: [ConfigService],
@@ -136,7 +138,7 @@ Second example with asynchronous configuration:
         connectionUri: configService.get<string>('AMQP_CONNECTION_URI'),
         throwExceptionOnConnectionError: true,
         connectionOptions: {
-          transport: 'tcp'
+          transport: configService.get<string>('AMQP_CONNECTION_TRANSPORT'),
         }
       }),
       inject: [ConfigService],

--- a/src/queue.module.spec.ts
+++ b/src/queue.module.spec.ts
@@ -60,13 +60,31 @@ describe('QueueModule', () => {
   });
 
   describe('forRoot()', () => {
-    it('should import as sync root module', async () => {
+    it('should work only with a connection URI', async () => {
       module = await Test.createTestingModule({
         imports: [QueueModule.forRoot(connectionUri)],
       }).compile();
       const amqpService = module.get<AMQPService>(AMQPService);
 
       expect(amqpService.getModuleOptions()).toEqual(moduleOptions);
+    });
+
+    it('should work with connection URI and module options arguments', async () => {
+      module = await Test.createTestingModule({
+        imports: [QueueModule.forRoot(connectionUri, { throwExceptionOnConnectionError: true })],
+      }).compile();
+      const amqpService = module.get<AMQPService>(AMQPService);
+
+      expect(amqpService.getModuleOptions()).toEqual({ throwExceptionOnConnectionError: true, connectionUri });
+    });
+
+    it('should work only with module options', async () => {
+      module = await Test.createTestingModule({
+        imports: [QueueModule.forRoot({ connectionUri, throwExceptionOnConnectionError: true })],
+      }).compile();
+      const amqpService = module.get<AMQPService>(AMQPService);
+
+      expect(amqpService.getModuleOptions()).toEqual({ throwExceptionOnConnectionError: true, connectionUri });
     });
   });
 

--- a/src/queue.module.ts
+++ b/src/queue.module.ts
@@ -17,8 +17,12 @@ export class QueueModule implements OnModuleInit, OnModuleDestroy {
     exports: [QueueService],
   };
 
-  public static forRoot(connectionUri: string, options?: Omit<QueueModuleOptions, 'connectionUri'>): DynamicModule {
-    const queueModuleOptionsProvider = QueueModule.getQueueModuleOptionsProvider({ ...options, connectionUri });
+  public static forRoot(options: QueueModuleOptions): DynamicModule;
+  public static forRoot(connectionUri: string, options?: Omit<QueueModuleOptions, 'connectionUri'>): DynamicModule;
+  public static forRoot(connectionUri: string | QueueModuleOptions, options?: Omit<QueueModuleOptions, 'connectionUri'>): DynamicModule {
+    const queueModuleOptionsProvider = QueueModule.getQueueModuleOptionsProvider(
+      typeof connectionUri === 'string' ? { ...options, connectionUri } : connectionUri,
+    );
     const connectionProvider = QueueModule.getConnectionProvider();
 
     Object.assign(QueueModule.moduleDefinition, {


### PR DESCRIPTION
This PR contains:
* refactor `QueueModule.forRoot()` to accept module options only
* add test cases
* update the documentation