### PR TITLE
feat(module): add option to make AMQP module available globally

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,9 @@ Instead of `useFactory` you can use `useClass` or `useExisting` to set module op
 #### Module options
 
 The module options object needs to be added to the `forRoot()` or `forRootAsync()` static method. The possible options can be these:
+* **isGlobal**?: A boolean value. If this property is `true`, then you can skip the import with`.forFeature()` method in the feature 
+  modules, because the public services will be available in all modules which imports the root module. Default value is
+  `false`. (You can read more about it on [Nest modules page](https://docs.nestjs.com/modules#global-modules))
 * **throwExceptionOnConnectionError**?: A boolean value. If it's `true` then AMQPModule will throw forward the exception which occurs
   during the connection creation. Default value is `false`.
 * **acceptValidationNullObjectException**?: A boolean value. If it's `true` then AMQPModule will accept the message when a
@@ -138,7 +141,8 @@ First basic example:
   imports: [
     QueueModule.forRoot(
       'amqp://user:password@localhost:5672', 
-      { 
+      {
+        isGlobal: true,
         throwExceptionOnConnectionError: true,
         connectionOptions: {
           transport: 'tcp'
@@ -155,6 +159,9 @@ Second example with asynchronous configuration:
 @Module({
   imports: [
     QueueModule.forRootAsync({
+      // in case of `QueueModule.forRootAsync`, isGlobal property goes here and
+      // not into the object returned by 'useFactory' or 'useClass' or 'useExisting'
+      isGlobal: true, 
       imports: [ConfigModule],
       useFactory: (configService: ConfigService): QueueModuleOptions => ({
         connectionUri: configService.get<string>('AMQP_CONNECTION_URI'),

--- a/src/interface/amqp-connection-options.interface.ts
+++ b/src/interface/amqp-connection-options.interface.ts
@@ -6,6 +6,7 @@ import { ConnectionOptions } from 'rhea-promise';
  * @publicApi
  */
 export type QueueModuleOptions = {
+  isGlobal?: boolean;
   throwExceptionOnConnectionError?: boolean;
   acceptValidationNullObjectException?: boolean;
   connectionUri?: string;

--- a/src/interface/queue-options.interface.ts
+++ b/src/interface/queue-options.interface.ts
@@ -7,6 +7,7 @@ export interface QueueModuleOptionsFactory {
 }
 
 export interface QueueModuleAsyncOptions extends Pick<ModuleMetadata, 'imports'> {
+  isGlobal?: boolean;
   useExisting?: Type<QueueModuleOptionsFactory>;
   useClass?: Type<QueueModuleOptionsFactory>;
   useFactory?: (...args: any[]) => Promise<QueueModuleOptions> | QueueModuleOptions;

--- a/src/queue.module.ts
+++ b/src/queue.module.ts
@@ -12,6 +12,7 @@ import { Logger } from './util';
 @Module({})
 export class QueueModule implements OnModuleInit, OnModuleDestroy {
   private static readonly moduleDefinition: DynamicModule = {
+    global: false,
     module: QueueModule,
     providers: [AMQPService, QueueService, MetadataScanner, ListenerExplorer, ObjectValidatorService],
     exports: [QueueService],
@@ -20,12 +21,12 @@ export class QueueModule implements OnModuleInit, OnModuleDestroy {
   public static forRoot(options: QueueModuleOptions): DynamicModule;
   public static forRoot(connectionUri: string, options?: Omit<QueueModuleOptions, 'connectionUri'>): DynamicModule;
   public static forRoot(connectionUri: string | QueueModuleOptions, options?: Omit<QueueModuleOptions, 'connectionUri'>): DynamicModule {
-    const queueModuleOptionsProvider = QueueModule.getQueueModuleOptionsProvider(
-      typeof connectionUri === 'string' ? { ...options, connectionUri } : connectionUri,
-    );
+    const moduleOptions = typeof connectionUri === 'string' ? { ...options, connectionUri } : connectionUri;
+    const queueModuleOptionsProvider = QueueModule.getQueueModuleOptionsProvider(moduleOptions);
     const connectionProvider = QueueModule.getConnectionProvider();
 
     Object.assign(QueueModule.moduleDefinition, {
+      global: !!moduleOptions.isGlobal,
       providers: [queueModuleOptionsProvider, ...QueueModule.moduleDefinition.providers, connectionProvider],
     });
 
@@ -37,6 +38,7 @@ export class QueueModule implements OnModuleInit, OnModuleDestroy {
     const asyncProviders = this.createAsyncProviders(options);
 
     Object.assign(QueueModule.moduleDefinition, {
+      global: !!options.isGlobal,
       imports: options.imports,
       providers: [...asyncProviders, ...QueueModule.moduleDefinition.providers, connectionProvider],
     });


### PR DESCRIPTION
This PR contains:
* add `isGlobal` module option to import `@team-supercharge/nest-amqp` globally
* add test cases
* update README