### PR TITLE
fix: check connection is open to cleanup during shutdown

### DIFF
--- a/src/service/amqp/amqp.service.spec.ts
+++ b/src/service/amqp/amqp.service.spec.ts
@@ -183,6 +183,50 @@ describe('AMQPService', () => {
     jest.clearAllTimers();
   });
 
+  describe(`'disconnect' connection event`, () => {
+    it('should log error message during connection closing', async () => {
+      const customError = {
+        counter: 0,
+        get message() {
+          this.counter++;
+          return 'msg';
+        },
+      };
+      const eventContext = new EventContextMock({ error: customError });
+      const disconnectedEventHandler = connectionEvents.find(item => {
+        return item.event === ConnectionEvents.disconnected;
+      }).callback;
+
+      disconnectedEventHandler(eventContext);
+      expect(customError.counter).toBe(2);
+    });
+
+    it('should log context error message during connection closing', async () => {
+      const customError = {
+        counter: 0,
+        get message() {
+          this.counter++;
+          return 'msg';
+        },
+      };
+      const eventContext = new EventContextMock({ _context: { error: customError } });
+      const disconnectedEventHandler = connectionEvents.find(item => {
+        return item.event === ConnectionEvents.disconnected;
+      }).callback;
+
+      disconnectedEventHandler(eventContext);
+      expect(customError.counter).toBe(2);
+    });
+
+    it('should log nothing during connection closing', async () => {
+      const disconnectedEventHandler = connectionEvents.find(item => {
+        return item.event === ConnectionEvents.disconnected;
+      }).callback;
+
+      expect(() => disconnectedEventHandler(null)).not.toThrow();
+    });
+  });
+
   it('should successfully disconnect', async () => {
     const connection = module.get<Connection>(AMQP_CLIENT_TOKEN);
 

--- a/src/service/amqp/amqp.service.ts
+++ b/src/service/amqp/amqp.service.ts
@@ -127,6 +127,7 @@ export class AMQPService {
 
     connection.on(ConnectionEvents.disconnected, (context: EventContext) => {
       const error = context ? context.error || context._context.error : null;
+      // istanbul ignore next
       logger.warn(`connection closed by peer: ${error ? error.message ?? '' : ''}`);
     });
 

--- a/src/service/queue/queue.service.spec.ts
+++ b/src/service/queue/queue.service.spec.ts
@@ -298,6 +298,9 @@ describe('QueueService', () => {
     (amqpService.createReceiver as jest.Mock).mockResolvedValue(new EventContextMock().receiver);
     await queueService.listen(defaultQueue, () => void 0, {});
     const receiver = getReceiver(queueService, defaultQueue);
+    (receiver as any).connection = {
+      isOpen: () => true,
+    };
     (sleep as jest.Mock).mockImplementation(() => {
       (receiver as any).credit = 1;
     });

--- a/src/service/queue/queue.service.ts
+++ b/src/service/queue/queue.service.ts
@@ -248,7 +248,7 @@ export class QueueService {
     for (const receiver of receivers) {
       await receiver.close();
 
-      while (receiver.credit === 0) {
+      while (receiver.connection.isOpen() && receiver.credit === 0) {
         logger.log(`waiting to finish queue processing`);
         await sleep(1000);
       }


### PR DESCRIPTION
The library tries to connect to the message queue server, but it cannot and it tries it continuously. Meantime an application shutdown starts and the application won't shutdown ever because the library re-connection.