### PR TITLE
feat(class-transformer): add support to v0.5.1 or newer v0.5.x versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   "peerDependencies": {
     "@nestjs/common": "^6.0.0 || ^7.0.0 || ^8.0.0",
     "@nestjs/core": "^6.0.0 || ^7.0.0 || ^8.0.0",
-    "class-transformer": "^0.3.0 || ^0.4.0",
+    "class-transformer": "^0.3.0 || ^0.4.0 || ^0.5.1",
     "class-validator": ">=0.13.2"
   }
 }


### PR DESCRIPTION
The following functions are renamed of class-transformer package and the earlier function names are marked as deprecated:
`classToPlain` -> `instanceToPlain`
`plainToClass` -> `plainToInstance`
`classToClass` -> `instanceToInstance`

With the next upcoming breaking change of the package we need to follow up the changes.