### PR TITLE
chore(rhea-promise): upgrade to v3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.6.3",
       "license": "MIT",
       "dependencies": {
-        "rhea-promise": "2.1.0"
+        "rhea-promise": "3.0.3"
       },
       "devDependencies": {
         "@commitlint/cli": "13.1.0",
@@ -4307,6 +4307,7 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -10282,21 +10283,57 @@
       }
     },
     "node_modules/rhea": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/rhea/-/rhea-2.0.4.tgz",
-      "integrity": "sha512-GpGqJV6dPG+bh88ZvlkzcaqKM3bW6+YDHSegSjdPkoCi3UIsWN6yu6i4LMhpojNg1U5UOGqshCoMMNO5Hkoeog==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/rhea/-/rhea-3.0.3.tgz",
+      "integrity": "sha512-Y7se0USZQu6dErWSZ7eCmSVTMscyVfz/0+jjhBF7f9PqYfEXdIoQpPkC9Strks6wF9WytuBhn8w8Nz/tmBWpgA==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "debug": "0.8.0 - 3.5.0"
+        "debug": "^4.3.3"
       }
     },
     "node_modules/rhea-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rhea-promise/-/rhea-promise-2.1.0.tgz",
-      "integrity": "sha512-CRMwdJ/o4oO/xKcvAwAsd0AHy5fVvSlqso7AadRmaaLGzAzc9LCoW7FOFnucI8THasVmOeCnv5c/fH/n7FcNaA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/rhea-promise/-/rhea-promise-3.0.3.tgz",
+      "integrity": "sha512-a875P5YcMkePSTEWMsnmCQS7Y4v/XvIw7ZoMtJxqtQRZsqSA6PsZxuz4vktyRykPuUgdNsA6F84dS3iEXZoYnQ==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "debug": "^3.1.0",
-        "rhea": "^2.0.3",
-        "tslib": "^2.2.0"
+        "debug": "^4.0.0",
+        "rhea": "^3.0.0",
+        "tslib": "^2.6.0"
+      }
+    },
+    "node_modules/rhea-promise/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/rhea/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/rimraf": {
@@ -11497,9 +11534,10 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -15477,6 +15515,7 @@
       "version": "3.2.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
+      "dev": true,
       "requires": {
         "ms": "^2.1.1"
       }
@@ -20067,21 +20106,41 @@
       "dev": true
     },
     "rhea": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/rhea/-/rhea-2.0.4.tgz",
-      "integrity": "sha512-GpGqJV6dPG+bh88ZvlkzcaqKM3bW6+YDHSegSjdPkoCi3UIsWN6yu6i4LMhpojNg1U5UOGqshCoMMNO5Hkoeog==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/rhea/-/rhea-3.0.3.tgz",
+      "integrity": "sha512-Y7se0USZQu6dErWSZ7eCmSVTMscyVfz/0+jjhBF7f9PqYfEXdIoQpPkC9Strks6wF9WytuBhn8w8Nz/tmBWpgA==",
       "requires": {
-        "debug": "0.8.0 - 3.5.0"
+        "debug": "^4.3.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+          "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        }
       }
     },
     "rhea-promise": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/rhea-promise/-/rhea-promise-2.1.0.tgz",
-      "integrity": "sha512-CRMwdJ/o4oO/xKcvAwAsd0AHy5fVvSlqso7AadRmaaLGzAzc9LCoW7FOFnucI8THasVmOeCnv5c/fH/n7FcNaA==",
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/rhea-promise/-/rhea-promise-3.0.3.tgz",
+      "integrity": "sha512-a875P5YcMkePSTEWMsnmCQS7Y4v/XvIw7ZoMtJxqtQRZsqSA6PsZxuz4vktyRykPuUgdNsA6F84dS3iEXZoYnQ==",
       "requires": {
-        "debug": "^3.1.0",
-        "rhea": "^2.0.3",
-        "tslib": "^2.2.0"
+        "debug": "^4.0.0",
+        "rhea": "^3.0.0",
+        "tslib": "^2.6.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.4.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+          "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+          "requires": {
+            "ms": "^2.1.3"
+          }
+        }
       }
     },
     "rimraf": {
@@ -20958,9 +21017,9 @@
       }
     },
     "tslib": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.0.tgz",
-      "integrity": "sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg=="
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "tsutils": {
       "version": "3.21.0",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "check": "npm run lint && npm run build && npm run test"
   },
   "dependencies": {
-    "rhea-promise": "2.1.0"
+    "rhea-promise": "3.0.3"
   },
   "devDependencies": {
     "@commitlint/cli": "13.1.0",

--- a/src/service/amqp/amqp.service.ts
+++ b/src/service/amqp/amqp.service.ts
@@ -83,7 +83,7 @@ export class AMQPService {
       host: hostname,
       port: Number.parseInt(port, 10),
       ...rheaConnectionOptions,
-    });
+    } as ConnectionOptions);
 
     connection.on(ConnectionEvents.connectionOpen, (_: EventContext) => {
       logger.log('connection opened');


### PR DESCRIPTION
Hello, love the library! I'm raising a PR to address  an amp:session:window:violation error I'm getting when running this library against Rabbit MQ 4.

This was addressed in the following [issue](https://github.com/amqp/rhea/issues/426) and [pr](https://github.com/amqp/rhea/pull/427).

I cannot find a rhea/rhea-promise v2 -> v3 migration guide. I've run the tests in the repo and I'm currently running this library with rhea and rhea-promise yarn resolutions at 3.0.3. I can verify (manually) that this is working with Rabbit MQ4 and Azure Service Bus.